### PR TITLE
#6 Syncing assets in UE level with maya scene

### DIFF
--- a/Plugins/ueGear/Content/Python/ueGear/actors.py
+++ b/Plugins/ueGear/Content/Python/ueGear/actors.py
@@ -103,6 +103,25 @@ def get_actor_by_label_in_current_level(actor_label):
     return found_actor
 
 
+def get_actor_by_guid_in_current_level(actor_guid):
+    """
+    Return actor within current level with the given actor guid.
+
+    :param str actor_guid: actor guid.
+    :return: found actor with given guid in current level.
+    :rtype: unreal.Actor or None
+    """
+
+    found_actor = None
+    all_actors = get_all_actors_in_current_level()
+    for actor in all_actors:
+        if actor.actor_guid.to_string() == actor_guid:
+            found_actor = actor
+            break
+
+    return found_actor
+
+
 def get_all_actors_with_component_of_type(component_class):
     found_actors = list()
     actors = unreal.EditorActorSubsystem().get_all_level_actors()

--- a/Plugins/ueGear/Content/Python/ueGear/commands.py
+++ b/Plugins/ueGear/Content/Python/ueGear/commands.py
@@ -216,17 +216,23 @@ class PyUeGearCommands(unreal.UeGearCommands):
             )
             return
 
+        mtx = unreal.Matrix(x_plane=[1, 0, 0, 0],
+                            y_plane=[0, 0, 1, 0],
+                            z_plane=[0, 1, 0, 0],
+                            w_plane=[0, 0, 0, 1]
+                            )
+
         ue_transform = unreal.Transform()
         rotation = ast.literal_eval(rotation)
-        ue_transform.rotation = unreal.Rotator(
-            rotation[0], rotation[1], rotation[2] * -1.0
-        ).quaternion()
-        ue_transform.translation = unreal.Vector(
-            *ast.literal_eval(translation)
-        )
+        ue_transform.rotation = unreal.Rotator(rotation[0], rotation[1], rotation[2]).quaternion()
+        ue_transform.translation = unreal.Vector(*ast.literal_eval(translation))
         ue_transform.scale3d = unreal.Vector(*ast.literal_eval(scale))
 
-        found_actor.set_actor_transform(ue_transform, False, False)
+        corrected_mtx =  mtx * ue_transform.to_matrix()
+        corrected_trans = corrected_mtx.transform()
+
+        # found_actor.set_actor_transform(ue_transform, False, False)
+        found_actor.set_actor_transform(corrected_trans, False, False)
 
     # ==================================================================================================================
     # STATIC MESHES

--- a/Plugins/ueGear/Content/Python/ueGear/commands.py
+++ b/Plugins/ueGear/Content/Python/ueGear/commands.py
@@ -197,22 +197,18 @@ class PyUeGearCommands(unreal.UeGearCommands):
         static=True,
         meta=dict(Category="ueGear Commands"),
     )
-    def set_actor_world_transform(actor_name, translation, rotation, scale):
+    def set_actor_world_transform(actor_guid, translation, rotation, scale):
         """
-        Sect the world transform of the actor with given name withing current opened level.
+        Sect the world transform of the actor with given GUID withing current opened level.
 
         :param str translation: actor world translation as a string [float, float, float] .
         :param str rotation: actor world rotation as a string [float, float, float].
         :param str scale: actor world scale as a string [float, float, float].
         """
-
-        # Actor is found using actor label within Unreal level.
-        # TODO: Actor labels are not unique, so if two actors have the same label then maybe we are going to update
-        # TODO: an undesired one. Try to find a workaround for this.
-        found_actor = actors.get_actor_by_label_in_current_level(actor_name)
+        found_actor = actors.get_actor_by_guid_in_current_level(actor_guid)
         if not found_actor:
             unreal.log_warning(
-                'No Actor found with label: "{}"'.format(actor_name)
+                'No Actor found with guid: "{}"'.format(actor_guid)
             )
             return
 

--- a/Plugins/ueGear/Content/Python/ueGear/commands.py
+++ b/Plugins/ueGear/Content/Python/ueGear/commands.py
@@ -216,23 +216,15 @@ class PyUeGearCommands(unreal.UeGearCommands):
             )
             return
 
-        mtx = unreal.Matrix(x_plane=[1, 0, 0, 0],
-                            y_plane=[0, 0, 1, 0],
-                            z_plane=[0, 1, 0, 0],
-                            w_plane=[0, 0, 0, 1]
-                            )
-
-        ue_transform = unreal.Transform()
+        maya_transform = unreal.Transform()
         rotation = ast.literal_eval(rotation)
-        ue_transform.rotation = unreal.Rotator(rotation[0], rotation[1], rotation[2]).quaternion()
-        ue_transform.translation = unreal.Vector(*ast.literal_eval(translation))
-        ue_transform.scale3d = unreal.Vector(*ast.literal_eval(scale))
+        maya_transform.rotation = unreal.Rotator(rotation[0], rotation[1], rotation[2]).quaternion()
+        maya_transform.translation = unreal.Vector(*ast.literal_eval(translation))
+        maya_transform.scale3d = unreal.Vector(*ast.literal_eval(scale))
 
-        corrected_mtx =  mtx * ue_transform.to_matrix()
-        corrected_trans = corrected_mtx.transform()
+        ue_transform = mayaio.convert_transform_maya_to_unreal(maya_transform)
 
-        # found_actor.set_actor_transform(ue_transform, False, False)
-        found_actor.set_actor_transform(corrected_trans, False, False)
+        found_actor.set_actor_transform(ue_transform, False, False)
 
     # ==================================================================================================================
     # STATIC MESHES

--- a/Plugins/ueGear/Content/Python/ueGear/commands.py
+++ b/Plugins/ueGear/Content/Python/ueGear/commands.py
@@ -376,9 +376,6 @@ class PyUeGearCommands(unreal.UeGearCommands):
 
         :param str directory: export directory.
         """
-
-        directory = r"E:\assets\warehouse\assets\output"
-
         layout_data = list()
         actors_mapping = dict()
 

--- a/Plugins/ueGear/Content/Python/ueGear/mayaio.py
+++ b/Plugins/ueGear/Content/Python/ueGear/mayaio.py
@@ -437,3 +437,23 @@ def import_camera(
     unreal.EditorAssetLibrary.save_asset(level_sequence_name)
 
     return True
+
+
+def convert_transform_maya_to_unreal(maya_transform):
+    """
+    Converts a unreal.Transform(), that stores Maya data, into a transformation matrix that
+    works in Unreal.
+
+    :param unreal.Transform() transform: Transform with Maya transformation data.
+
+    :return: Maya transformation now in Unreal transform space.
+    :rtype: unreal.Transform()
+    """
+    mtx = unreal.Matrix(x_plane=[1, 0, 0, 0],
+                            y_plane=[0, 0, 1, 0],
+                            z_plane=[0, 1, 0, 0],
+                            w_plane=[0, 0, 0, 1]
+                            )
+
+    corrected_mtx =  mtx * maya_transform.to_matrix()
+    return corrected_mtx.transform()

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Unreal Engine Gear
 **New tools:**
   - Core libraries
 
-### mGear 4.3 counterpart/Pipeline tools for ueGear
+#### mGear 4.3 counterpart/Pipeline tools for ueGear
 These tools will be implemented in mGear
 
 **Goal:**
@@ -19,7 +19,7 @@ These tools will be implemented in mGear
 ### ueGear 0.2 Roadmap Goals
 **Goal:** 
   - Syncing selected assets in Unreal Levels with Maya.
-
+  
 
 ### ueGear 1.0 Roadmap Goals
 **Goal:** 
@@ -36,7 +36,7 @@ These tools will be implemented in mGear
   - ueShifter:
     - EPIC component counterpart to build from Collected data in Maya
 
-### mGear 4.3 counterpart/Pipeline tools for ueGear
+#### mGear 4.3 counterpart/Pipeline tools for ueGear
 These tools will be implemented in mGear
 
 **Goal:**
@@ -49,30 +49,11 @@ These tools will be implemented in mGear
   - FBX exporter  
       - 1click send to Unreal (FBX) Skeletal mesh and animation
 
-
-# ===================
-#   DEVELOPER NOTES
-# ===================
-
 # DESIGN DECISIONS
 - Always starting from Unreal
 - Always assume camera exist in sequencer first.
 - A Sequencer Track represents one shot.
-
-
-# TASKS:
-[X] Export Camera
-[ ] Get Cameras From Sequencer
-  [X] Actor in Level
-  [X] Instanced Actor
-  [?] Subsequence Actor
-
-[ ] Commands from Maya
-  [ ] Query Unreal for FPS, check if it is the same as Maya, alert user before importing Cameras
-    [ ] Show dialog if fps are different
-
-[ ] Investigate if it is possible for Maya to not require FBX_SDK for Unreal export commands.
-  - Currently it fails if you do not have FBX_SDK and try and perform an object export.
+- Unreal assets are the ground truth for transform data. As transform data in maya will not represent final numeric values due to the different world axis.
 
 # Unreal Plugins
 The following plugins must be activated in your project to get the full benefit of ueGear.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 Unreal Engine Gear
 
 
+### ueGear 0.1 Roadmap Goals
+**Goal:** 
+  - IO layout data (Cameras + static Mesh + skeletal mesh)
+
+**New tools:**
+  - Core libraries
+
+### mGear 4.3 counterpart/Pipeline tools for ueGear
+These tools will be implemented in mGear
+
+**Goal:**
+ - improve game pipeline
+
+
+### ueGear 0.2 Roadmap Goals
+**Goal:** 
+  - Syncing selected assets in Unreal Levels with Maya.
+
+
 ### ueGear 1.0 Roadmap Goals
 **Goal:** 
 
@@ -30,16 +49,15 @@ These tools will be implemented in mGear
   - FBX exporter  
       - 1click send to Unreal (FBX) Skeletal mesh and animation
 
+
 # ===================
 #   DEVELOPER NOTES
 # ===================
 
 # DESIGN DECISIONS
 - Always starting from Unreal
-- Always assume camera in sequencer
-Unreal > Maya > Unreal camera flows
-- Adding custom attributes on Camera to FBX
-- A shot represents one Camera track.
+- Always assume camera exist in sequencer first.
+- A Sequencer Track represents one shot.
 
 
 # TASKS:


### PR DESCRIPTION
https://github.com/mgear-dev/ueGear/issues/6

Unreal to Maya and back
- Imports assets into Maya from Unreal
- Updates position in Maya of asset in Unreal
- Performs transform conversion to and from Unreal Space to Maya Space. *Note:* Maya values will have scale negated and rotations.
- Unreal Assets in Level are the ground truth for position information.
- Updates to Unreal uses GUID, so no worry about name changes. 

