### PR TITLE
Added Sequencer fps command

### DIFF
--- a/Plugins/ueGear/Content/Python/ueGear/commands.py
+++ b/Plugins/ueGear/Content/Python/ueGear/commands.py
@@ -152,6 +152,9 @@ class PyUeGearCommands(unreal.UeGearCommands):
 
         level_sequencer_path_name = sequencer.get_current_level_sequence().get_path_name()
 
+        # Gets the framerate of the Sequencer.
+        fps = sequencer.get_framerate(sequencer.get_current_level_sequence())
+
         camera_bindings = sequencer.get_selected_cameras()
         if not camera_bindings:
             return []
@@ -168,6 +171,17 @@ class PyUeGearCommands(unreal.UeGearCommands):
             meta_data.append(asset_export_data)
 
         return meta_data
+
+    @unreal.ufunction(
+        ret=int,
+        static=True,
+        meta=dict(Category="ueGear Commands")
+        )
+    def get_selected_sequencer_fps():
+        """
+        Returns the active Sequencer's fps
+        """
+        return sequencer.get_framerate(sequencer.get_current_level_sequence())
 
     @unreal.ufunction(
         params=[str, str, str],

--- a/README.md
+++ b/README.md
@@ -41,21 +41,6 @@ Unreal > Maya > Unreal camera flows
 - Adding custom attributes on Camera to FBX
 - A shot represents one Camera track.
 
-
-# TASKS:
-[X] Export Camera
-[ ] Get Cameras From Sequencer
-  [X] Actor in Level
-  [X] Instanced Actor
-  [?] Subsequence Actor
-
-[ ] Commands from Maya
-  [ ] Query Unreal for FPS, check if it is the same as Maya, alert user before importing Cameras
-    [ ] Show dialog if fps are different
-
-[ ] Investigate if it is possible for Maya to not require FBX_SDK for Unreal export commands.
-  - Currently it fails if you do not have FBX_SDK and try and perform an object export.
-
 # Unreal Plugins
 The following plugins must be activated in your project to get the full benefit of ueGear.
 - `Python Editor Script Plugin`


### PR DESCRIPTION
Issue: https://github.com/mgear-dev/ueGear/issues/8

Importing cameras into Maya now checks the Maya fps, and warns the user that the fps do not match, or updates mayas fps before importing the camera data