### PR TITLE
CR Layer fix

### DIFF
--- a/Plugins/ueGear/Content/Python/ueGear/assets.py
+++ b/Plugins/ueGear/Content/Python/ueGear/assets.py
@@ -518,7 +518,7 @@ def get_selected_folders(relative=False):
     """
     paths = []
 
-    folder_paths =  unreal.EditorUtilityLibrary.get_selected_folder_paths()
+    folder_paths = unreal.EditorUtilityLibrary.get_selected_folder_paths()
 
     if relative:
         return folder_paths

--- a/Plugins/ueGear/Content/Python/ueGear/controlrig/manager.py
+++ b/Plugins/ueGear/Content/Python/ueGear/controlrig/manager.py
@@ -130,7 +130,7 @@ class UEGearManager:
         if not create_ctrl:
             return
 
-        # Creates the Forward,Backwards and Construction event
+        # Creates the Forward, Backwards and Construction event
         self.create_solves()
 
         # Create Automatic built world control

--- a/Plugins/ueGear/Content/Python/ueGear/mayaio.py
+++ b/Plugins/ueGear/Content/Python/ueGear/mayaio.py
@@ -450,28 +450,29 @@ def convert_transform_maya_to_unreal(maya_transform, world_up):
     :return: Maya transformation now in Unreal transform space.
     :rtype: unreal.Transform()
     """
-    convertion_mtx = unreal.Matrix(x_plane=[1, 0, 0, 0],
-                             y_plane=[0, 0, -1, 0],
-                             z_plane=[0, 1, 0, 0],
-                             w_plane=[0, 0, 0, 1]
-                            )
+    convertion_mtx = unreal.Matrix(
+        x_plane=[1, 0, 0, 0],
+        y_plane=[0, 0, -1, 0],
+        z_plane=[0, 1, 0, 0],
+        w_plane=[0, 0, 0, 1]
+    )
 
     if world_up == 'y':
-        corrected_mtx =  convertion_mtx * maya_transform.to_matrix() * convertion_mtx.get_inverse()
-        # update Rotation
-        euler = maya_transform.rotation.euler()
-        quat = unreal.Quat()
-        quat.set_from_euler(unreal.Vector(euler.x + 90, euler.y, euler.z))
-        trans = corrected_mtx.transform()
-        trans.rotation = quat
 
-        # Update Position
-        pos = trans.translation
-        pos_y =  pos.y
-        pos_z =  pos.z
-        pos.y =  pos_z
-        pos.z =  -pos_y
-        trans.translation = pos
+        original_euler = maya_transform.rotation.euler()
+        original_quat = maya_transform.rotation
+
+        # Calculates the correct converted position in world space
+        quat = unreal.Quat()
+        quat.set_from_euler(unreal.Vector(0, 0, 0))
+        maya_transform.rotation = quat
+        corrected_mtx = convertion_mtx * maya_transform.to_matrix()
+        trans = corrected_mtx.transform()
+
+        # update Rotation
+        quat = unreal.Quat()
+        quat.set_from_euler(unreal.Vector(original_euler.x + 90, original_euler.y, -original_euler.z))
+        trans.rotation = quat
 
     elif world_up == 'z':
         corrected_mtx = maya_transform.to_matrix() * convertion_mtx

--- a/Plugins/ueGear/Content/Python/ueGear/sequencer/sequencer.py
+++ b/Plugins/ueGear/Content/Python/ueGear/sequencer/sequencer.py
@@ -292,7 +292,7 @@ def import_fbx_camera(name: str, sequence: unreal.LevelSequence, fbx_path: str):
     fbx_config = unreal.MovieSceneUserImportFBXSettings()
     seq_tools = unreal.SequencerTools()
 
-    fbx_config.set_editor_property("match_by_name_only", True)
+    fbx_config.set_editor_property("match_by_name_only", False)
     fbx_config.set_editor_property("replace_transform_track", True)
     fbx_config.set_editor_property("create_cameras", False)
 


### PR DESCRIPTION
The Control Rig components now work better with the UE CR Layer Track.


## Description of Changes

- Camera track importing no longer relies on the name of the fbx parent node's name, instead we have deactivated use names, and we rely on the track matching that occurs in Maya. The reason for this is due to names with spaces. Maya cannot have cameras with spaces

- Camera Fix for updating camera
- Static Object updating. Note: there is still a possibilty of gimbal rotation locking when updating an asset. This needs to be looked at further
- Leg Forward and Backwards Solve

## Testing Done

Tested against our test scene and in unreal 5.4, 5.3

## Related Issue(s)

Please link the related issues.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Contributor License Agreement (CLA)](https://github.com/mgear-dev/ueGear/blob/main/Contributor_License_Agreement.md). Please use the CLA assistant to sign the CLA


