### PR TITLE
[Bug Fix] Remote Control Python Object Path

### DIFF
--- a/Plugins/ueGear/Content/Python/ueGear/commands.py
+++ b/Plugins/ueGear/Content/Python/ueGear/commands.py
@@ -15,16 +15,6 @@ import unreal
 
 from . import helpers, mayaio, structs, tag, assets, actors, textures, sequencer
 
-# TODO: Remove the imports once we release into production
-# importlib.reload(helpers)
-# importlib.reload(structs)
-# importlib.reload(tag)
-# importlib.reload(assets)
-# importlib.reload(actors)
-# importlib.reload(textures)
-# importlib.reload(mayaio)
-
-
 # TODO: For some reason, unreal.Array(float) parameters defined within ufunction params argument are not
 # TODO: with the correct number of elements within the list. As a temporal workaround, we convert them
 # TODO: to strings in the client side and we parse them here.
@@ -32,12 +22,13 @@ from . import helpers, mayaio, structs, tag, assets, actors, textures, sequencer
 
 
 @unreal.uclass()
-class PyUeGearCommands(unreal.UeGearCommands):
-    # ==================================================================================================================
-    # OVERRIDES
-    # ==================================================================================================================
+class PyUeGearCommands(unreal.BlueprintFunctionLibrary):
 
-    @unreal.ufunction(override=True, meta=dict(Category="ueGear Commands"))
+    @unreal.ufunction(ret=str, static=True, meta=dict(Category="ueGear Commands"))
+    def get_unreal_version():
+        return unreal.SystemLibrary.get_engine_version()
+
+    @unreal.ufunction(meta=dict(Category="ueGear Commands"))
     def import_maya_data(self):
         """
         Opens a file window that allow users to choose a JSON file that contains all the info needed to import asset or
@@ -46,7 +37,7 @@ class PyUeGearCommands(unreal.UeGearCommands):
 
         mayaio.import_data()
 
-    @unreal.ufunction(override=True, meta=dict(Category="ueGear Commands"))
+    @unreal.ufunction(meta=dict(Category="ueGear Commands"))
     def import_maya_layout(self):
         """
         Opens a file window that allow users to choose a JSON file that contains layout data to load.
@@ -54,7 +45,7 @@ class PyUeGearCommands(unreal.UeGearCommands):
 
         mayaio.import_layout_from_file()
 
-    @unreal.ufunction(override=True, meta=dict(Category="ueGear Commands"))
+    @unreal.ufunction(meta=dict(Category="ueGear Commands"))
     def export_unreal_layout(self):
         """
         Exports a layout JSON file based on the objects on the current Unreal level.
@@ -62,7 +53,7 @@ class PyUeGearCommands(unreal.UeGearCommands):
 
         mayaio.export_layout_file()
 
-    @unreal.ufunction(override=True, meta=dict(Catergory="ueGear Commands"))
+    @unreal.ufunction(meta=dict(Catergory="ueGear Commands"))
     def generate_uegear_ui(self):
         """
         """
@@ -78,9 +69,7 @@ class PyUeGearCommands(unreal.UeGearCommands):
     # PATHS
     # ==================================================================================================================
 
-    @unreal.ufunction(
-        ret=str, static=True, meta=dict(Category="ueGear Commands")
-    )
+    @unreal.ufunction(ret=str, static=True, meta=dict(Category="ueGear Commands"))
     def project_content_directory():
         """
         Returns the content directory of the current game.

--- a/Plugins/ueGear/Source/ueGear/Private/ueGear.cpp
+++ b/Plugins/ueGear/Source/ueGear/Private/ueGear.cpp
@@ -39,27 +39,6 @@ void FueGearModule::AddMenuEntry(FMenuBarBuilder& MenuBarBuilder)
 
 void FueGearModule::FillMenu(FMenuBuilder& MenuBuilder)
 {
-//	MenuBuilder.AddMenuEntry(
-//		FText::FromString("Import Maya Data"),
-//		FText::FromString("Import Maya Data from ueGear Maya Data"),
-//		FSlateIcon(),
-//		FUIAction(FExecuteAction::CreateRaw(this, &FueGearModule::ImportMayaDataCallback))
-//	);
-//
-//	MenuBuilder.AddMenuEntry(
-//	FText::FromString("Import Maya Layout"),
-//	FText::FromString("Import Unreal Layout Data"),
-//	FSlateIcon(),
-//	FUIAction(FExecuteAction::CreateRaw(this, &FueGearModule::ImportMayaLayoutCallback))
-//	);
-//
-//	MenuBuilder.AddMenuEntry(
-//	FText::FromString("Export Unreal Layout"),
-//	FText::FromString("Export Unreal Layout Data"),
-//	FSlateIcon(),
-//	FUIAction(FExecuteAction::CreateRaw(this, &FueGearModule::ExportUnrealLayoutCallback))
-//	);
-
 	MenuBuilder.AddMenuEntry(
 		FText::FromString("Generate ueGear Rig"),
 		FText::FromString("Generates a ueGear Control Rig from an mGear context."),
@@ -67,24 +46,6 @@ void FueGearModule::FillMenu(FMenuBuilder& MenuBuilder)
 		FUIAction(FExecuteAction::CreateRaw(this, &FueGearModule::GenerateUegearUiCallback))
 	);
 }
-
-//void FueGearModule::ImportMayaDataCallback()
-//{
-//	UUeGearCommands* ueGearCommands = UUeGearCommands::Get();
-//	ueGearCommands->ImportMayaData();
-//}
-//
-//void FueGearModule::ImportMayaLayoutCallback()
-//{
-//	UUeGearCommands* ueGearCommands = UUeGearCommands::Get();
-//	ueGearCommands->ImportMayaLayout();
-//}
-//
-//void FueGearModule::ExportUnrealLayoutCallback()
-//{
-//	UUeGearCommands* ueGearCommands = UUeGearCommands::Get();
-//	ueGearCommands->ExportUnrealLayout();
-//}
 
 void FueGearModule::GenerateUegearUiCallback()
 {

--- a/Plugins/ueGear/Source/ueGear/Public/UeGearCommands.h
+++ b/Plugins/ueGear/Source/ueGear/Public/UeGearCommands.h
@@ -14,16 +14,4 @@ class UEGEAR_API UUeGearCommands : public UObject
 public:
 	UFUNCTION(BlueprintCallable, Category=ueGear)
 	static UUeGearCommands* Get();
-
-	UFUNCTION(BlueprintImplementableEvent, Category=ueGear)
-	void ImportMayaData();
-
-	UFUNCTION(BlueprintImplementableEvent, Category=ueGear)
-	void ImportMayaLayout();
-
-	UFUNCTION(BlueprintImplementableEvent, Category=ueGear)
-	void ExportUnrealLayout();
-
-	UFUNCTION(BlueprintImplementableEvent, Category=ueGear)
-	void GenerateUegearUi();
 };

--- a/Plugins/ueGear/Source/ueGear/Public/ueGear.h
+++ b/Plugins/ueGear/Source/ueGear/Public/ueGear.h
@@ -19,8 +19,5 @@ private:
 	void AddMenuEntry(FMenuBarBuilder& MenuBarBuilder);
 	void FillMenu(FMenuBuilder& MenuBuilder);
 	
-	void ImportMayaDataCallback();
-	void ImportMayaLayoutCallback();
-	void ExportUnrealLayoutCallback();
 	void GenerateUegearUiCallback();
 };


### PR DESCRIPTION
## Description of Changes

- Removed redundant overides and C++ methods
- Added unreal version query command.

## Testing Done

Used Maya mGear to trigger remote commands in 5.3 and 5.5 both now working


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Contributor License Agreement (CLA)](https://github.com/mgear-dev/ueGear/blob/main/Contributor_License_Agreement.md). Please use the CLA assistant to sign the CLA


