### PR TITLE
Move ueGear menu into Tools menu

### DIFF
--- a/Plugins/ueGear/Source/ueGear/Private/ueGear.cpp
+++ b/Plugins/ueGear/Source/ueGear/Private/ueGear.cpp
@@ -3,6 +3,7 @@
 #include "ueGear.h"
 
 #include "LevelEditor.h"
+#include "ToolMenus.h"
 #include "UeGearCommands.h"
 
 #define LOCTEXT_NAMESPACE "FueGearModule"
@@ -11,30 +12,33 @@ DEFINE_LOG_CATEGORY(ueGearLog)
 
 void FueGearModule::StartupModule()
 {
-	UE_LOG(ueGearLog, Log, TEXT("Creating ueGear Menus"));
-	FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule> ("LevelEditor");
-	TSharedPtr<FExtender> MenuExtender = MakeShareable(new FExtender());
-	MenuExtender->AddMenuBarExtension(
-		"Help",
-		EExtensionHook::Before,
-		nullptr,
-		FMenuBarExtensionDelegate::CreateRaw(this, &FueGearModule::AddMenuEntry));
-	LevelEditorModule.GetMenuExtensibilityManager()->AddExtender(MenuExtender);
+	UToolMenus::RegisterStartupCallback(FSimpleMulticastDelegate::FDelegate::CreateRaw(this, &FueGearModule::RegisterMenu));
 }
 
 void FueGearModule::ShutdownModule()
 {
-	IModuleInterface::ShutdownModule();
+	UToolMenus::UnRegisterStartupCallback(this);
+	UToolMenus::UnregisterOwner(this);
 }
 
-void FueGearModule::AddMenuEntry(FMenuBarBuilder& MenuBarBuilder)
+void FueGearModule::RegisterMenu()
 {
-	MenuBarBuilder.AddPullDownMenu(
-		LOCTEXT("MenuLocKey", "ueGear"),
-		LOCTEXT("MenuTooltipKey", "Opens ueGear Menu"),
-		FNewMenuDelegate::CreateRaw(this, &FueGearModule::FillMenu),
-		FName(TEXT("ueGear")),
-		FName(TEXT("ueGear")));
+	UE_LOG(ueGearLog, Log, TEXT("Creating ueGear Menus"));
+
+	FToolMenuOwnerScoped OwnerScoped(this);
+	{
+		UToolMenu* Menu = UToolMenus::Get()->ExtendMenu("LevelEditor.MainMenu.Tools");
+		FToolMenuSection& Section = Menu->FindOrAddSection("Rigging", LOCTEXT("MenuSectKey", "Rigging"));
+		Section.AddSubMenu(
+			FName(TEXT("ueGear")),
+			LOCTEXT("MenuLocKey", "ueGear"),
+			LOCTEXT("MenuTooltipKey", "Opens ueGear Menu"),
+			FNewMenuDelegate::CreateRaw(this, &FueGearModule::FillMenu),
+			false,
+			FSlateIcon(),
+			false,
+			FName(TEXT("ueGear")));
+	}
 }
 
 void FueGearModule::FillMenu(FMenuBuilder& MenuBuilder)

--- a/Plugins/ueGear/Source/ueGear/Public/ueGear.h
+++ b/Plugins/ueGear/Source/ueGear/Public/ueGear.h
@@ -16,7 +16,7 @@ public:
 
 private:
 	
-	void AddMenuEntry(FMenuBarBuilder& MenuBarBuilder);
+	void RegisterMenu();
 	void FillMenu(FMenuBuilder& MenuBuilder);
 	
 	void GenerateUegearUiCallback();

--- a/Plugins/ueGear/Source/ueGear/ueGear.Build.cs
+++ b/Plugins/ueGear/Source/ueGear/ueGear.Build.cs
@@ -41,6 +41,7 @@ public class ueGear : ModuleRules
 				"PythonScriptPlugin",
 				"RemoteControl",
 				"UnrealEd",
+				"ToolMenus",
 			}
 			);
 		


### PR DESCRIPTION
## Description of Changes

Moved the ueGear menu into the Tools menu, which is the preferred location for plugin menu items. Placed it in a section named Rigging, which is where Epic's Pose Driver Connect plugin has its menu

## Testing Done

Tested in 5.6 editor

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Contributor License Agreement (CLA)](https://github.com/mgear-dev/ueGear/blob/main/Contributor_License_Agreement.md). Please use the CLA assistant to sign the CLA


